### PR TITLE
changed: temporary remove API endpoint

### DIFF
--- a/app/Resources/views/iiif.html.twig
+++ b/app/Resources/views/iiif.html.twig
@@ -6,7 +6,7 @@
     <h1>{{ 'IIIF' }}</h1>
     <p>IIIF frees up your images to be creatively reused. Because scaling, cropping and zooming become trivial operations, you’re free to concentrate on the important task of providing a great user experience. You also benefit from great image viewing software written and maintained by other people, so no need to reinvent the wheel.</p>
     <p>IIIF is used in the imagehub to serve images and the technical and administrative metadata needed to view those images in an embedded online viewer. The imagehub features an implementation of the IIIF Presentation 2.1. API.</p>
-    <p>Find the IIIF Presentation API endpoint at <a href="https://imagehub.vlaamsekunstcollectie.be/iiif/2/">https://imagehub.vlaamsekunstcollectie.be/iiif/2/</a></p>
+    <!-- <p>Find the IIIF Presentation API endpoint at <a href="https://imagehub.vlaamsekunstcollectie.be/iiif/2/">https://imagehub.vlaamsekunstcollectie.be/iiif/2/</a></p> -->
     <p>All manifests available in this API endpoint can be found in a top-level IIIF collection at <a href="http://imagehub.vlaamsekunstcollectie.be/iiif/2/collection/top">http://imagehub.vlaamsekunstcollectie.be/iiif/2/collection/top</a></p>
     <p>You can find more information about the IIIF Presentation and Image APIs at <a href="http://iiif.io">iiif.io</a></p>
     <p>Find more information about the Cantaloupe Image server <a href="https://cantaloupe-project.github.io/">https://cantaloupe-project.github.io/</a></p>

--- a/src/AppBundle/Imagehub/Controller/IIIFController.php
+++ b/src/AppBundle/Imagehub/Controller/IIIFController.php
@@ -10,6 +10,7 @@ class IIIFController extends Controller
 {
     /**
      * @Route("/iiif", name="iiif")
+     * @Route("/iiif/", name="iiif")
      */
     public function iiifAction(Request $request)
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In the IIIF-webpage of imagehub the endpoint to the Presentation API.

## Motivation and context

It's not working and it's also not necessary. The top level collection is the interesting part.

not really fixing, but helps to avoid #28 